### PR TITLE
Update API Version

### DIFF
--- a/dev.sites.json
+++ b/dev.sites.json
@@ -10,28 +10,6 @@
       ],
       "from": "dev.redirects.p4.greenpeace.org",
       "to": "www.greenpeace.org"
-    },    
-    {
-      "owners": [
-        {
-         "name": "P4 Administrator",
-         "email": "planet4.ops@greenpeace.org",
-         "unit": "GPI Operations"
-        }
-      ],
-      "from": "jencub.club",
-      "to": "www-dev.greenpeace.org/jctest"
-    },
-    {
-      "owners": [
-        {
-         "name": "P4 Administrator",
-         "email": "planet4.ops@greenpeace.org",
-         "unit": "GPI Operations"
-        }
-      ],
-      "from": "www.jencub.club",
-      "to": "www-dev.greenpeace.org/jctest"
     }
   ]
 }

--- a/ingress.yaml.tmpl
+++ b/ingress.yaml.tmpl
@@ -1,9 +1,8 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: redirects-nginx
     p4.kubernetes.io/redirect-owners: "{{ .Env.OWNERS }}"
     p4.kubernetes.io/redirect-description: "{{ .Env.DESCRIPTION }}"
     nginx.ingress.kubernetes.io/rewrite-target: "https://{{ .Env.TO }}/$1"
@@ -13,6 +12,7 @@ metadata:
   name: redirects-{{ .Env.NAME }}
   namespace: {{ default .Env.NAMESPACE "default" }}
 spec:
+  ingressClassName: redirects-nginx
   tls:
     - hosts:
         - {{ .Env.FROM }}
@@ -23,5 +23,7 @@ spec:
         paths:
           - path: /(.*)
             backend:
-              serviceName: p4-robots-static
-              servicePort: 80
+              service:
+                name: p4-robots-static
+                port:
+                  number: 80

--- a/ingress.yaml.tmpl
+++ b/ingress.yaml.tmpl
@@ -22,6 +22,7 @@ spec:
       http:
         paths:
           - path: /(.*)
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: p4-robots-static


### PR DESCRIPTION
Update the API version for global redirect Ingress resources. This is so we can remove deprecated APIs that will prevent upgrading