### PR TITLE
Add cee.press.gp.org redirect

### DIFF
--- a/prod.sites.json
+++ b/prod.sites.json
@@ -476,6 +476,17 @@
       ],
       "from": "www.greenpeace.bg",
       "to": "www.greenpeace.org/bulgaria"
+    },
+    {
+      "owners": [
+        {
+         "name": "Rastislav Prochazka",
+         "emal": "rastislav.prochazka@greenpeace.org ",
+         "unit": "Greenpeace CEE"
+        }
+      ],
+      "from": "cee.press.greenpeace.org",
+      "to": "greenpeace.at/cee-press-hub"
     }
   ]
 }


### PR DESCRIPTION
Add SSL redirect for Greenpeace CEE.
See ticket: https://help.greenpeace.org/staff/ticket/101852