### PR TITLE
Add a redirect for Ukraine TLD

### DIFF
--- a/prod.sites.json
+++ b/prod.sites.json
@@ -505,6 +505,28 @@
       ],
       "from": "museumofclimatejustice.org",
       "to": "www.museumofclimatejustice.org"
+    },
+    {
+      "owners": [
+        {
+          "name": "Marton Torok",
+          "email": "marton.torok@greenpeace.org",
+          "unit": "Greenpeace Ukraine"
+        }
+      ],
+      "from": "greenpeace.ua",
+      "to": "www.greenpeace.org/ukraine"
+    },
+    {
+      "owners": [
+        {
+          "name": "Marton Torok",
+          "email": "marton.torok@greenpeace.org",
+          "unit": "Greenpeace Ukraine"
+        }
+      ],
+      "from": "www.greenpeace.ua",
+      "to": "www.greenpeace.org/ukraine"
     }
   ]
 }


### PR DESCRIPTION
Ukraine P4 website is now live. So they want their main domain to redirect to that.