### PR TITLE
Change permanent redirect to preserve query parameters

### DIFF
--- a/ingress.yaml.tmpl
+++ b/ingress.yaml.tmpl
@@ -5,8 +5,7 @@ metadata:
   annotations:
     p4.kubernetes.io/redirect-owners: "{{ .Env.OWNERS }}"
     p4.kubernetes.io/redirect-description: "{{ .Env.DESCRIPTION }}"
-    nginx.ingress.kubernetes.io/rewrite-target: "https://{{ .Env.TO }}/$1"
-    nginx.ingress.kubernetes.io/permanent-redirect: https://{{ .Env.TO }}/$1
+    nginx.ingress.kubernetes.io/permanent-redirect: https://{{ .Env.TO }}/$request_uri
     cert-manager.io/issuer: letsencrypt-prod
   labels:
     app: redirects


### PR DESCRIPTION
- changed ingress annotations to use $request_uri top preserve query strings.
- removed unneeded rewrite-target annotation