### PR TITLE
Remove extra / from permanent-redirect

### DIFF
--- a/ingress.yaml.tmpl
+++ b/ingress.yaml.tmpl
@@ -5,7 +5,7 @@ metadata:
   annotations:
     p4.kubernetes.io/redirect-owners: "{{ .Env.OWNERS }}"
     p4.kubernetes.io/redirect-description: "{{ .Env.DESCRIPTION }}"
-    nginx.ingress.kubernetes.io/permanent-redirect: https://{{ .Env.TO }}/$request_uri
+    nginx.ingress.kubernetes.io/permanent-redirect: https://{{ .Env.TO }}$request_uri
     cert-manager.io/issuer: letsencrypt-prod
   labels:
     app: redirects


### PR DESCRIPTION
The extra / means we get a double one which is not blocking anything but not that nice.